### PR TITLE
Change gradle to 5.6.4; Fix the bug when metrics are too long

### DIFF
--- a/app/src/main/jni/roofline/GPUdriver.cpp
+++ b/app/src/main/jni/roofline/GPUdriver.cpp
@@ -642,10 +642,10 @@ Java_com_google_gables_Roofline_GPUExecute(JNIEnv *env, jobject thiz, jobject as
             uint64_t total_bytes = t * working_set_size * bytes_per_elem * mem_accesses_per_elem;
             uint64_t total_flops = t * working_set_size * nFlops * flops_per_elem;
 
-            results << std::right << std::setw(12) << working_set_size * bytes_per_elem
-                    << std::right << std::setw(12) << t
-                    << std::right << std::setw(15) << total_seconds * 1000000
-                    << std::right << std::setw(12) << total_bytes
+            results << std::right << std::setw(12) << working_set_size * bytes_per_elem << " "
+                    << std::right << std::setw(12) << t << " "
+                    << std::right << std::setw(15) << total_seconds * 1000000 << " "
+                    << std::right << std::setw(12) << total_bytes << " "
                     << std::right << std::setw(12) << total_flops
                     << std::endl;
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
Change gradle to 5.6.4 since it is the minimal version that the newest Android Studio accepts.